### PR TITLE
improvement / phpspec-is-now-runnable and some deprecation fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor
+.idea
 
 /coverage
 coverage.clover

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,6 +1,3 @@
-extensions:
-  Cjm\PhpSpec\Extension\TypeHintedMethodsExtension: ~
-
 suites:
   default:
     spec_path: tests

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -6,9 +6,10 @@ use ArrayIterator;
 use DusanKasan\Knapsack\Exceptions\InvalidArgument;
 use DusanKasan\Knapsack\Exceptions\InvalidReturnValue;
 use IteratorAggregate;
+use Serializable;
 use Traversable;
 
-class Collection implements IteratorAggregate, \Serializable, CollectionInterface
+class Collection implements IteratorAggregate, Serializable, CollectionInterface
 {
     use CollectionTrait;
 
@@ -95,7 +96,7 @@ class Collection implements IteratorAggregate, \Serializable, CollectionInterfac
      * {@inheritdoc}
      * @throws InvalidReturnValue
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         if ($this->inputFactory) {
             $input = call_user_func($this->inputFactory);
@@ -137,5 +138,23 @@ class Collection implements IteratorAggregate, \Serializable, CollectionInterfac
     public function unserialize($serialized)
     {
         $this->input = dereferenceKeyValue(unserialize($serialized));
+    }
+
+
+    public function __serialize(): array
+    {
+        return toArray(
+            map(
+                $this->input,
+                function ($value, $key) {
+                    return [$key, $value];
+                }
+            )
+        );
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->input = dereferenceKeyValue($data);
     }
 }

--- a/src/collection_functions.php
+++ b/src/collection_functions.php
@@ -356,7 +356,9 @@ function sort($collection, callable $function)
     uasort(
         $array,
         function ($a, $b) use ($function) {
-            return $function($a[1], $b[1], $a[0], $b[0]);
+            $result = $function($a[1], $b[1], $a[0], $b[0]);
+
+            return is_numeric($result) ? $result : ($result ? 1 : -1);
         }
     );
 

--- a/tests/spec/CollectionSpec.php
+++ b/tests/spec/CollectionSpec.php
@@ -336,7 +336,7 @@ class CollectionSpec extends ObjectBehavior
 
     function it_can_execute_callback_for_each_item(DOMXPath $a)
     {
-        $a->query('asd')->shouldBeCalled();
+        $a->query('asd')->shouldBeCalled()->willReturn([]);
         $this->beConstructedWith([$a]);
 
         $this


### PR DESCRIPTION
I think its safer for us to keep phpspec running as we will know that our changes, our upgrades does not break everything.

command which now works:

`vendor/bin/phpspec run --config phpspec.yml`

right now produces result:

![image](https://github.com/stockfiller/Knapsack/assets/17051250/aaf7bd29-48a7-47b7-9263-e5461f137b46)
