### PR TITLE
improvement/phpunit-is-now-runnable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage.clover
 coverage.xml
 
 phpunit.xml
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "DusanKasan\\Knapsack\\Tests\\Helpers\\": "tests/helpers/"
+      "DusanKasan\\Knapsack\\Tests\\Helpers\\": "tests/helpers/",
+      "DusanKasan\\Knapsack\\Tests\\Scenarios\\": "tests/scenarios/"
     }
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit bootstrap="vendor/autoload.php">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd" bootstrap="vendor/autoload.php"
+         colors="true" executionOrder="random" beStrictAboutChangesToGlobalState="true"
+         beStrictAboutResourceUsageDuringSmallTests="true" beStrictAboutOutputDuringTests="true" testdox="true">
     <testsuites>
-        <testsuite>
+        <testsuite name="Scenarions">
             <directory>tests/scenarios</directory>
         </testsuite>
     </testsuites>
+    <logging/>
 </phpunit>
 

--- a/tests/scenarios/CallableFunctionNamesTest.php
+++ b/tests/scenarios/CallableFunctionNamesTest.php
@@ -3,9 +3,9 @@
 namespace DusanKasan\Knapsack\Tests\Scenarios;
 
 use DusanKasan\Knapsack\Collection;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class CallableFunctionNamesTest extends PHPUnit_Framework_TestCase
+class CallableFunctionNamesTest extends TestCase
 {
     /**
      * Example that it's possible to use callable function names as arguments.

--- a/tests/scenarios/CustomPassthroughFunctionTest.php
+++ b/tests/scenarios/CustomPassthroughFunctionTest.php
@@ -3,9 +3,9 @@
 namespace DusanKasan\Knapsack\Tests\Scenarios;
 
 use DusanKasan\Knapsack\Collection;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class CustomPassthroughFunctionTest extends PHPUnit_Framework_TestCase
+class CustomPassthroughFunctionTest extends TestCase
 {
     /**
      * Example of implementing a transpose function and how to apply it over a collection.

--- a/tests/scenarios/FibonaccisSequenceTest.php
+++ b/tests/scenarios/FibonaccisSequenceTest.php
@@ -3,9 +3,9 @@
 namespace DusanKasan\Knapsack\Tests\Scenarios;
 
 use DusanKasan\Knapsack\Collection;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class FibonaccisSequenceTest extends PHPUnit_Framework_TestCase
+class FibonaccisSequenceTest extends TestCase
 {
     /**
      * Example generating first 5 values in fibonacci's sequence.

--- a/tests/scenarios/GroupingFlightsTest.php
+++ b/tests/scenarios/GroupingFlightsTest.php
@@ -3,13 +3,13 @@
 namespace DusanKasan\Knapsack\Tests\Scenarios;
 
 use DusanKasan\Knapsack\Collection;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * More advanced usage of collection pipeline, see
  * http://martinfowler.com/articles/refactoring-pipelines.html#GroupingFlightRecords for reference.
  */
-class GroupingFlightsTest extends PHPUnit_Framework_TestCase
+class GroupingFlightsTest extends TestCase
 {
     private $inputData = [
         [

--- a/tests/scenarios/MultipleOperationsTest.php
+++ b/tests/scenarios/MultipleOperationsTest.php
@@ -3,9 +3,9 @@
 namespace DusanKasan\Knapsack\Tests\Scenarios;
 
 use DusanKasan\Knapsack\Collection;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class MultipleOperationsTest extends PHPUnit_Framework_TestCase
+class MultipleOperationsTest extends TestCase
 {
     /**
      * Example of a longer pipeline. If this was real code, you should probably split it into smaller chunks.


### PR DESCRIPTION
phpunit tests are now runnable.

just running `vendor/bin/phpunit` will run existing tests:

![image](https://github.com/stockfiller/Knapsack/assets/17051250/82aa56a2-08f5-4d6b-83a8-18327bab2a61)
