### PR TITLE
Rnd / buggy behavior for mapcat

### DIFF
--- a/tests/helpers/FastCar.php
+++ b/tests/helpers/FastCar.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace DusanKasan\Knapsack\Tests\Helpers;
+
+class FastCar
+{
+    public function __construct(public readonly string $name, public readonly array $parts) {}
+}

--- a/tests/helpers/Part.php
+++ b/tests/helpers/Part.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace DusanKasan\Knapsack\Tests\Helpers;
+
+class Part
+{
+    public function __construct(public readonly string $partName) {}
+}


### PR DESCRIPTION
You can see unit tests I wrote. If you forget `->values()` then the mapcat will merge an array by the keys. However if you include it, then the array won't merge .

Prior what I knew is that we always use `indexBy` to return unique values from mapcat operation. It turns out this is not needed.

**Now the question is: maybe we should include an autofix so mapcat always returns all values ?** 