### PR TITLE
fix: implicitly marking parameter as nullable is deprecated warning

### DIFF
--- a/src/collection_functions.php
+++ b/src/collection_functions.php
@@ -245,7 +245,7 @@ function map($collection, callable $function)
  * @param callable|null $function ($value, $key)
  * @return Collection
  */
-function filter($collection, callable $function = null)
+function filter($collection, ?callable $function = null)
 {
     if (null === $function) {
         $function = function ($value) {


### PR DESCRIPTION
Fixes the PHP 8.4 Warning: Implicitly marking parameter $function as nullable is deprecated, the explicit nullable type must be used instead